### PR TITLE
feat: Add 'description' enum field to Parcel entity (#1)

### DIFF
--- a/src/main/java/com/poryvai/post/controller/ParcelController.java
+++ b/src/main/java/com/poryvai/post/controller/ParcelController.java
@@ -7,6 +7,7 @@ import com.poryvai.post.dto.UpdateParcelStatusRequest;
 import com.poryvai.post.model.Parcel;
 import com.poryvai.post.model.ParcelStatus;
 import com.poryvai.post.service.ParcelService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -85,7 +86,7 @@ public class ParcelController {
      * to handle validation errors (HTTP 400).
      */
     @PostMapping
-    public Parcel create(@RequestBody CreateParcelRequest request) {
+    public Parcel create(@Valid @RequestBody CreateParcelRequest request) {
         return parcelService.create(request);
     }
 

--- a/src/main/java/com/poryvai/post/dto/CreateParcelRequest.java
+++ b/src/main/java/com/poryvai/post/dto/CreateParcelRequest.java
@@ -1,6 +1,8 @@
 package com.poryvai.post.dto;
 
 import com.poryvai.post.model.DeliveryType;
+import com.poryvai.post.model.ParcelDescription;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -34,4 +36,11 @@ public class CreateParcelRequest {
      * The requested delivery type for the parcel. Can be null, defaulting to DEFAULT.
      */
     private DeliveryType deliveryType;
+
+    /**
+     * The description category of the parcel's contents (e.g., CLOTHES, BOOKS).
+     * This field is required when creating a new parcel.
+     */
+    @NotNull
+    private ParcelDescription parcelDescription;
 }

--- a/src/main/java/com/poryvai/post/dto/ParcelSearchParams.java
+++ b/src/main/java/com/poryvai/post/dto/ParcelSearchParams.java
@@ -1,6 +1,7 @@
 package com.poryvai.post.dto;
 
 import com.poryvai.post.model.DeliveryType;
+import com.poryvai.post.model.ParcelDescription;
 import com.poryvai.post.model.ParcelStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -68,4 +69,11 @@ public class ParcelSearchParams {
      */
     @Builder.Default
     private List<DeliveryType> deliveryTypes = new ArrayList<>();
+
+    /**
+     * A list of parcel descriptions to include in the search.
+     * Parcels with any of the specified delivery types will be returned.
+     */
+    @Builder.Default
+    private List<ParcelDescription> parcelDescriptions = new ArrayList<>();
 }

--- a/src/main/java/com/poryvai/post/dto/ParcelStatistic.java
+++ b/src/main/java/com/poryvai/post/dto/ParcelStatistic.java
@@ -2,6 +2,7 @@ package com.poryvai.post.dto;
 
 import com.poryvai.post.model.DeliveryType;
 import com.poryvai.post.model.Parcel;
+import com.poryvai.post.model.ParcelDescription;
 import com.poryvai.post.model.ParcelStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +47,11 @@ public class ParcelStatistic {
      * A map showing the count of parcels for each delivery type (e.g., DEFAULT, EXPRESS, ECONOM).
      */
     private Map<DeliveryType, Long> parcelsCountByDeliveryType;
+
+    /**
+     * A map showing the count of parcels for each description type (e.g., CLOTHES, SPARE_PARTS, GROCERIES, BOOKS, MEDICATIONS, HOME_APPLIANCES).
+     */
+    private Map<ParcelDescription, Long> parcelsCountByDescription;
 
     /**
      * The parcel with the highest price among those matching the search criteria.

--- a/src/main/java/com/poryvai/post/model/Parcel.java
+++ b/src/main/java/com/poryvai/post/model/Parcel.java
@@ -73,4 +73,12 @@ public class Parcel {
     @Enumerated(EnumType.STRING)
     @Column(name = "delivery_type", nullable = false, length = 20)
     private DeliveryType deliveryType;
+
+    /**
+     * The type of description chosen for the parcel.
+     * Stored as a string in the database.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "description", nullable = false, length = 20)
+    private ParcelDescription parcelDescription;
 }

--- a/src/main/java/com/poryvai/post/model/ParcelDescription.java
+++ b/src/main/java/com/poryvai/post/model/ParcelDescription.java
@@ -1,0 +1,38 @@
+package com.poryvai.post.model;
+
+/**
+ * Represents the category or type of contents within a parcel.
+ * This helps in classifying parcels for various purposes like logistics,
+ * customs declarations, or statistical analysis.
+ */
+public enum ParcelDescription {
+
+    /**
+     * The parcel primarily contains clothing items.
+     */
+    CLOTHES,
+    /**
+     * The parcel primarily contains automotive or machinery spare parts.
+     */
+    SPARE_PARTS,
+    /**
+     * The parcel primarily contains food items, groceries, or perishable goods.
+     */
+    GROCERIES,
+    /**
+     * The parcel primarily contains books, magazines, or other printed materials.
+     */
+    BOOKS,
+    /**
+     * The parcel primarily contains pharmaceutical products or medical supplies.
+     */
+    MEDICATIONS,
+    /**
+     * The parcel primarily contains large or small appliances for home use.
+     */
+    HOME_APPLIANCES,
+    /**
+     * The parcel contains miscellaneous items not covered by other specific categories.
+     */
+    MISCELLANEOUS
+}

--- a/src/main/java/com/poryvai/post/service/ParcelService.java
+++ b/src/main/java/com/poryvai/post/service/ParcelService.java
@@ -20,7 +20,7 @@ public interface ParcelService {
      *
      * @param trackingNumber The unique tracking number used to identify the parcel.
      * @return The {@link Parcel} object corresponding to the given tracking number.
-     * @throws com.example.demo.exception.NotFoundException if no parcel with the specified tracking number is found.
+     * @throws com.poryvai.post.exception.NotFoundException if no parcel with the specified tracking number is found.
      * This exception is typically handled by a global exception handler (e.g., RestExceptionHandler).
      */
     Parcel getByTrackingNumber(String trackingNumber);
@@ -29,7 +29,7 @@ public interface ParcelService {
      * Retrieves a paginated and filtered list of parcels.
      * This method supports dynamic queries based on various search parameters.
      *
-     * @param params   An object containing optional search criteria (e.g., sender, recipient, status).
+     * @param params   An object containing optional search criteria (e.g., sender, recipient, status, parcel descriptions).
      * @param pageable An object defining pagination (page number, size) and sorting options.
      * @return A {@link Page} of {@link Parcel} objects that match the criteria.
      */
@@ -37,7 +37,8 @@ public interface ParcelService {
 
     /**
      * Builds and returns a statistical summary of parcels based on specified search parameters.
-     * This includes aggregate data such as total counts, averages, and counts by different categories.
+     * This includes aggregate data such as total counts, averages, and counts by different categories,
+     * and counts by parcel description types.
      *
      * @param params An object containing optional filters to scope the statistics calculation.
      * @return A {@link ParcelStatistic} object containing the aggregated statistical data.
@@ -47,7 +48,7 @@ public interface ParcelService {
     /**
      * Creates a new parcel based on the provided request data.
      * This method handles the generation of tracking numbers, price calculation,
-     * and initial status setting for the parcel.
+     * and initial status setting, and assigning the parcel's description.
      *
      * @param request The {@link CreateParcelRequest} containing all necessary data for parcel creation.
      * @return The newly created {@link Parcel} object, persisted in the database.
@@ -62,7 +63,7 @@ public interface ParcelService {
      * @param trackingNumber The unique tracking number of the parcel to be updated.
      * @param status         The new {@link ParcelStatus} to set for the parcel.
      * @return The updated {@link Parcel} object.
-     * @throws com.example.demo.exception.NotFoundException if no parcel with the specified tracking number is found.
+     * @throws com.poryvai.post.exception.NotFoundException if no parcel with the specified tracking number is found.
      * This exception is typically handled by a global exception handler (e.g., RestExceptionHandler).
      */
     Parcel updateStatus(String trackingNumber, ParcelStatus status);

--- a/src/main/java/com/poryvai/post/util/ParcelSpecifications.java
+++ b/src/main/java/com/poryvai/post/util/ParcelSpecifications.java
@@ -76,6 +76,11 @@ public class ParcelSpecifications {
                 predicates.add(root.get("deliveryType").in(params.getDeliveryTypes()));
             }
 
+            // 8. Filter by parcel descriptions
+            if (params.getParcelDescriptions() != null && !params.getParcelDescriptions().isEmpty()) {
+                predicates.add(root.get("description").in(params.getParcelDescriptions())); // <-- ДОБАВЬТЕ ЭТОТ БЛОК
+            }
+
             // Combine all collected predicates with an AND logical operator.
             // If no predicates, it will result in a query that fetches all records (effectively 'true').
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));


### PR DESCRIPTION
This pull request introduces a new description field to the Parcel entity, allowing for better categorization and detailed tracking of parcel contents. This enhancement improves data granularity for search, statistics, and future features.

Key Changes:

ParcelDescription Enum: A new enum ParcelDescription has been created to define a standardized set of parcel content categories (e.g., CLOTHES, BOOKS, GROCERIES). Each enum value includes Javadoc for clarity.
Parcel Entity Update:
The Parcel entity now includes a parcelDescription field, mapped as a VARCHAR in the database with nullable = false.
DTO Updates:
CreateParcelRequest.java: Updated to include the parcelDescription field, marked with @NotNull to ensure it's mandatory during parcel creation.
ParcelSearchParams.java: A new parcelDescriptions list has been added to allow searching for parcels based on one or more description types.
ParcelStatistic.java: The ParcelStatistic DTO now includes parcelCountByDescription to provide statistical counts of parcels per description type.
Service Layer (ParcelService / ParcelServiceImpl) Enhancements:
The create method in ParcelServiceImpl now correctly assigns the parcelDescription from the CreateParcelRequest to the Parcel entity.
The buildStatistic method has been extended to calculate and include counts for each ParcelDescription type in the ParcelStatistic output.
JPA Specifications Update (ParcelSpecifications.java):
The withDynamicQuery method in ParcelSpecifications has been enhanced to filter parcels by the new parcelDescriptions search parameter, using the in operator for multiple values.
Controller Layer (ParcelController.java) Adjustment:
The create method in ParcelController has been annotated with @Valid for CreateParcelRequest, enabling proper validation for the mandatory parcelDescription field.

Closes #1