### PR TITLE
feat: Implement PostOffice dynamic search and pagination

### DIFF
--- a/src/main/java/com/poryvai/post/controller/PostOfficeController.java
+++ b/src/main/java/com/poryvai/post/controller/PostOfficeController.java
@@ -1,11 +1,14 @@
 package com.poryvai.post.controller;
 
 import com.poryvai.post.dto.CreatePostOfficeRequest;
+import com.poryvai.post.dto.PostOfficeSearchParams;
 import com.poryvai.post.model.PostOffice;
 import com.poryvai.post.service.PostOfficeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,14 +52,18 @@ public class PostOfficeController {
     }
 
     /**
-     * Retrieves all post offices.
+     * Retrieves a paginated list of post offices, allowing for dynamic filtering based on various criteria.
      *
-     * @return A list of all {@link PostOffice} objects. HTTP status 200 OK.
+     * @param params   {@link PostOfficeSearchParams} containing optional filters such as name, city, postcode, and street.
+     * These parameters are typically passed as request parameters (query string).
+     * @param pageable {@link Pageable} object for pagination and sorting (e.g., page=0&size=10&sort=id,asc).
+     * Automatically resolved by Spring from request parameters.
+     * @return A {@link Page} of {@link PostOffice} objects matching the search criteria.
      */
     @GetMapping
-    List<PostOffice> getAll(){
-        log.info("Received request to get all post offices");
-        return postOfficeService.getAll();
+    public Page<PostOffice> findAll(PostOfficeSearchParams params, Pageable pageable) {
+        log.info("Received request to find all post offices with params: {} and pageable: {}", params, pageable);
+        return postOfficeService.findAll(params, pageable);
     }
 
     /**
@@ -84,4 +91,6 @@ public class PostOfficeController {
         log.info("Received request to delete post office by ID: {}", id);
         postOfficeService.delete(id);
     }
+
+
 }

--- a/src/main/java/com/poryvai/post/dto/PostOfficeSearchParams.java
+++ b/src/main/java/com/poryvai/post/dto/PostOfficeSearchParams.java
@@ -1,0 +1,37 @@
+package com.poryvai.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for searching PostOffice entities with dynamic criteria.
+ * Allows filtering by name, city, postcode, and street.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostOfficeSearchParams {
+
+    /**
+     * Name of the post office for case-insensitive search.
+     */
+    private String name;
+
+    /**
+     * City name where the post office is located, for case-insensitive search.
+     */
+    private String city;
+
+    /**
+     * Postcode of the post office for case-insensitive search.
+     */
+    private String postcode;
+
+    /**
+     * Street address of the post office for case-insensitive search.
+     */
+    private String street;
+}

--- a/src/main/java/com/poryvai/post/repository/PostOfficeRepository.java
+++ b/src/main/java/com/poryvai/post/repository/PostOfficeRepository.java
@@ -2,12 +2,14 @@ package com.poryvai.post.repository;
 
 import com.poryvai.post.model.PostOffice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+
 /**
- * Spring Data JPA repository for the {@link PostOffice} entity.
- * Provides standard CRUD operations and custom query capabilities for PostOffice.
+ * Repository interface for {@link PostOffice} entities.
+ * Provides standard CRUD operations and allows for execution of {@link org.springframework.data.jpa.domain.Specification} based queries.
  */
 @Repository
-public interface PostOfficeRepository extends JpaRepository<PostOffice, Long> {
+public interface PostOfficeRepository extends JpaRepository<PostOffice, Long>, JpaSpecificationExecutor<PostOffice> {
 }

--- a/src/main/java/com/poryvai/post/service/PostOfficeService.java
+++ b/src/main/java/com/poryvai/post/service/PostOfficeService.java
@@ -1,7 +1,10 @@
 package com.poryvai.post.service;
 
 import com.poryvai.post.dto.CreatePostOfficeRequest;
+import com.poryvai.post.dto.PostOfficeSearchParams;
 import com.poryvai.post.model.PostOffice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -53,4 +56,13 @@ public interface PostOfficeService {
      * @throws com.poryvai.post.exception.NotFoundException if no post office with the specified ID is found.
      */
     void delete(Long id);
+
+    /**
+     * Retrieves a paginated list of PostOffice entities based on dynamic search parameters.
+     *
+     * @param params   {@link PostOfficeSearchParams} containing optional filters for post offices.
+     * @param pageable {@link Pageable} object for pagination and sorting.
+     * @return A {@link Page} of {@link PostOffice} objects matching the search criteria.
+     */
+    Page<PostOffice> findAll(PostOfficeSearchParams params, Pageable pageable);
 }

--- a/src/main/java/com/poryvai/post/service/PostOfficeServiceImpl.java
+++ b/src/main/java/com/poryvai/post/service/PostOfficeServiceImpl.java
@@ -1,11 +1,15 @@
 package com.poryvai.post.service;
 
 import com.poryvai.post.dto.CreatePostOfficeRequest;
+import com.poryvai.post.dto.PostOfficeSearchParams;
 import com.poryvai.post.exception.NotFoundException;
 import com.poryvai.post.model.PostOffice;
 import com.poryvai.post.repository.PostOfficeRepository;
+import com.poryvai.post.util.PostOfficeSpecifications;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,5 +108,18 @@ public class PostOfficeServiceImpl implements PostOfficeService{
             throw new NotFoundException("Post Office with ID " + id + " not found");
         }
         postOfficeRepository.deleteById(id);
+    }
+
+    /**
+     * Retrieves a paginated list of PostOffice entities based on dynamic search parameters.
+     *
+     * @param params   {@link PostOfficeSearchParams} containing optional filters for post offices.
+     * @param pageable {@link Pageable} object for pagination and sorting.
+     * @return A {@link Page} of {@link PostOffice} objects matching the search criteria.
+     */
+    @Override
+    public Page<PostOffice> findAll(PostOfficeSearchParams params, Pageable pageable) {
+        log.info("Retrieving post offices with search parameters: {} and pageable: {}", params, pageable);
+        return postOfficeRepository.findAll(PostOfficeSpecifications.bySearchParams(params), pageable);
     }
 }

--- a/src/main/java/com/poryvai/post/util/PostOfficeSpecifications.java
+++ b/src/main/java/com/poryvai/post/util/PostOfficeSpecifications.java
@@ -1,0 +1,57 @@
+package com.poryvai.post.util;
+
+import com.poryvai.post.model.PostOffice;
+import com.poryvai.post.dto.PostOfficeSearchParams;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for building JPA Specifications for PostOffice entities.
+ * Provides methods to create dynamic queries based on PostOfficeSearchParams.
+ */
+public class PostOfficeSpecifications {
+
+    /**
+     * Creates a Specification for filtering PostOffice entities based on provided search parameters.
+     *
+     * @param params The {@link PostOfficeSearchParams} containing the criteria.
+     * @return A {@link Specification} that can be used with Spring Data JPA repositories.
+     */
+    public static Specification<PostOffice> bySearchParams(PostOfficeSearchParams params) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // 1. Filter by name (case-insensitive, like)
+            if (StringUtils.hasText(params.getName())) {
+                predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("name")),
+                        "%" + params.getName().toLowerCase() + "%"));
+            }
+
+            // 2. Filter by city (case-insensitive, like)
+            if (StringUtils.hasText(params.getCity())) {
+                predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("city")),
+                        "%" + params.getCity().toLowerCase() + "%"));
+            }
+
+            // 3. Filter by postcode (case-insensitive, like)
+            if (StringUtils.hasText(params.getPostcode())) {
+                predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("postcode")),
+                        "%" + params.getPostcode().toLowerCase() + "%"));
+            }
+
+            // 4. Filter by street (case-insensitive, like)
+            if (StringUtils.hasText(params.getStreet())) {
+                predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("street")),
+                        "%" + params.getStreet().toLowerCase() + "%"));
+            }
+
+            // Combine all collected predicates with an AND logical operator.
+            // If no predicates, it will result in a query that fetches all records (effectively 'true').
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}


### PR DESCRIPTION
This pull request introduces dynamic search and pagination capabilities for PostOffice entities. Users can now filter post offices based on various criteria like name, city, postcode, and street, and retrieve paginated results.

What's been done:

1. PostOfficeSearchParams DTO: Created a new DTO (`com.poryvai.post.dto.PostOfficeSearchParams`) to encapsulate various search parameters for post offices. Includes `@Builder` and detailed Javadoc comments.
2. PostOfficeSpecifications Utility: Implemented `com.poryvai.post.util.PostOfficeSpecifications` to dynamically build JPA `Specification` queries based on the provided `PostOfficeSearchParams`, supporting case-insensitive 'like' searches.
3. PostOfficeRepository Update: Extended `PostOfficeRepository` to implement `JpaSpecificationExecutor<PostOffice>`, enabling specification-based queries.
4. PostOfficeService Enhancement: Added `findAll(PostOfficeSearchParams params, Pageable pageable)` method to `PostOfficeService` and `PostOfficeServiceImpl` to handle paginated and filtered queries, utilizing the new `PostOfficeSpecifications`.
5. PostOfficeController Update: Replaced the simple `getAll()` endpoint with a more flexible `GET /api/v1/post-offices` endpoint that accepts `PostOfficeSearchParams` and `Pageable` parameters. This allows for powerful filtering and pagination directly from the API.
6. Logging: Ensured appropriate `log.info()` statements are present in relevant service and controller methods for improved observability.

How to Verify:

- Test the new `GET /api/v1/post-offices` endpoint in Postman with various combinations of query parameters (e.g., `?city=Kyiv`, `?name=Central&postcode=01001`, `?page=0&size=2&sort=city,asc`).
- Confirm that filtering, pagination, and sorting work as expected.

Closes #9