### PR TITLE
feat: Establish Parcel-PostOffice Relationships (#18)

### DIFF
--- a/src/main/java/com/poryvai/post/controller/ParcelController.java
+++ b/src/main/java/com/poryvai/post/controller/ParcelController.java
@@ -81,19 +81,24 @@ public class ParcelController {
     /**
      * Creates a new parcel record in the system.
      * The parcel's tracking number will be automatically generated, and its price calculated
-     * based on the provided weight and delivery type.
+     * based on the provided weight and delivery type. The parcel will be associated with
+     * the specified origin and destination post offices.
      *
      * @param request The {@link CreateParcelRequest} object containing details for the new parcel.
      * This object is expected in the request body (JSON).
      * It should be valid according to its validation annotations (e.g., @NotBlank, @Positive).
      * @return The created {@link Parcel} object, including its generated tracking number and calculated price.
      * This method relies on {@link com.poryvai.post.controller.RestExceptionHandler}
-     * to handle validation errors (HTTP 400).
+     * to handle validation errors (HTTP 400) or {@link com.poryvai.post.exception.NotFoundException}
+     * if the specified post offices do not exist.
      */
     @PostMapping
     public Parcel create(@Valid @RequestBody CreateParcelRequest request) {
-        log.info("Received request to create parcel for sender: {}, recipient: {}", request.getSender(),
-                request.getRecipient());
+        log.info("Received request to create parcel for sender: {}, recipient: {} from origin PostOffice ID: {}, to destination PostOffice ID: {}",
+                request.getSender(),
+                request.getRecipient(),
+                request.getOriginPostOfficeId(),
+                request.getDestinationPostOfficeId());
         return parcelService.create(request);
     }
 

--- a/src/main/java/com/poryvai/post/dto/CreateParcelRequest.java
+++ b/src/main/java/com/poryvai/post/dto/CreateParcelRequest.java
@@ -2,7 +2,10 @@ package com.poryvai.post.dto;
 
 import com.poryvai.post.model.DeliveryType;
 import com.poryvai.post.model.ParcelDescription;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,16 +23,22 @@ public class CreateParcelRequest {
     /**
      * The name or identifier of the sender. Must not be blank.
      */
+    @NotBlank(message = "Sender cannot be blank")
+    @Size(max = 128, message = "Sender name must be less than or equal to 128 characters")
     private String sender;
 
     /**
      * The name or identifier of the recipient. Must not be blank.
      */
+    @NotBlank(message = "Recipient cannot be blank")
+    @Size(max = 128, message = "Recipient name must be less than or equal to 128 characters")
     private String recipient;
 
     /**
      * The weight of the parcel in kilograms. Must be a positive value.
      */
+    @NotNull(message = "Weight cannot be null")
+    @DecimalMin(value = "0.01", message = "Weight must be greater than 0")
     private double weight;
 
     /**
@@ -41,6 +50,22 @@ public class CreateParcelRequest {
      * The description category of the parcel's contents (e.g., CLOTHES, BOOKS).
      * This field is required when creating a new parcel.
      */
-    @NotNull
+    @NotNull(message = "Parcel description cannot be null")
     private ParcelDescription parcelDescription;
+
+    /**
+     * The ID of the post office where the parcel originated.
+     * Must be a positive number and cannot be null.
+     */
+    @NotNull(message = "Origin post office ID cannot be null")
+    @DecimalMin(value = "1", message = "Origin post office ID must be a positive number")
+    private Long originPostOfficeId;
+
+    /**
+     * The ID of the post office where the parcel is destined to be delivered.
+     * Must be a positive number and cannot be null.
+     */
+    @NotNull(message = "Destination post office ID cannot be null")
+    @DecimalMin(value = "1", message = "Destination post office ID must be a positive number")
+    private Long destinationPostOfficeId;
 }

--- a/src/main/java/com/poryvai/post/model/Parcel.java
+++ b/src/main/java/com/poryvai/post/model/Parcel.java
@@ -37,13 +37,13 @@ public class Parcel {
     /**
      * The name or identifier of the parcel's sender.
      */
-    @Column(name = "sender", nullable = false)
+    @Column(name = "sender", nullable = false, length = 128)
     private String sender;
 
     /**
      * The name or identifier of the parcel's recipient.
      */
-    @Column(name = "recipient", nullable = false)
+    @Column(name = "recipient", nullable = false, length = 128)
     private String recipient;
 
     /**
@@ -81,4 +81,18 @@ public class Parcel {
     @Enumerated(EnumType.STRING)
     @Column(name = "description", nullable = false, length = 20)
     private ParcelDescription parcelDescription;
+
+    /**
+     * The origin post office from which the parcel was sent.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "origin_post_office_id", nullable = false)
+    private PostOffice originPostOffice;
+
+    /**
+     * The destination post office where the parcel is intended to be delivered.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_post_office_id", nullable = false)
+    private PostOffice destinationPostOffice;
 }


### PR DESCRIPTION
This pull request establishes the `ManyToOne` relationships between the `Parcel` entity and the `PostOffice` entity. It allows parcels to be directly associated with an origin and destination post office, enhancing data integrity and application logic.

What's been done:

1. Parcel Entity (`com.poryvai.post.model.Parcel`):
    - Introduced `@ManyToOne` relationships for `originPostOffice` and `destinationPostOffice` fields, linking parcels to specific post office entities.
    - Updated `@Column` annotations for `sender` and `recipient` to specify a `length` of 128 characters, ensuring consistency and proper database schema.
    - Set the `length` of the `parcelDescription` column to 20, matching the maximum length of enum values.

2. CreateParcelRequest DTO (`com.poryvai.post.dto.CreateParcelRequest`):
    - Added `originPostOfficeId` and `destinationPostOfficeId` fields (type `Long`) with `@NotNull` and `@DecimalMin(1)` validation, as these are now required for parcel creation.
    - Removed the `price` field, as parcel price is now calculated dynamically in the service layer based on weight and delivery type.
    - Removed the `@NotNull` annotation from `deliveryType` to support defaulting to `DeliveryType.DEFAULT` if not provided in the request.
    - Adjusted `@Size` validation for `sender` and `recipient` to `max = 128` characters, mirroring the entity changes.
    - Added comprehensive Javadoc for all fields, clarifying their purpose and validation rules.

3. ParcelServiceImpl (`com.poryvai.post.service.ParcelServiceImpl`):
    - Modified the `create` method to fetch `PostOffice` entities from the `PostOfficeRepository` using the provided `originPostOfficeId` and `destinationPostOfficeId`.
    - Ensured `NotFoundException` is thrown if either specified `PostOffice` does not exist.
    - Set the fetched `PostOffice` objects directly onto the `Parcel` entity before saving, leveraging JPA's relationship management.

4. ParcelController (`com.poryvai.post.controller.ParcelController`):
    - Updated the Javadoc for the `create` method to reflect that parcels are now associated with origin and destination post offices, and to mention potential `NotFoundException` for invalid post office IDs.
    - Enhanced the `log.info` message within the `create` method to include `originPostOfficeId` and `destinationPostOfficeId` for better debugging and traceability.

How to Verify:

 - Prerequisites: Ensure your database has at least two `PostOffice` records (e.g., with IDs 1 and 2). If not, insert them manually via SQL.
- Run the application.
- Use Postman (or similar tool) to test the `create` endpoint:
     `POST /api/v1/parcels`
    Headers: `Content-Type: application/json`
    Body (raw, JSON):
        ```json
        {
            "sender": "John Doe",
            "recipient": "Jane Smith",
            "weight": 5.5,
            "deliveryType": "EXPRESS",
            "parcelDescription": "CLOTHES",
            "originPostOfficeId": 1, 
            "destinationPostOfficeId": 2
        }
        ```
    - Verify successful creation: Expect HTTP 200 OK with the full `Parcel` object including embedded `originPostOffice` and `destinationPostOffice` objects.
    - Verify validation errors (HTTP 400): Test with missing or invalid `originPostOfficeId`/`destinationPostOfficeId` (e.g., `null`, `0`).
    - Verify "Not Found" errors (HTTP 404): Test with non-existent `originPostOfficeId`/`destinationPostOfficeId` (e.g., 999).


Closes #18