### PR TITLE
Refactor: Sync Parcel DTO mapping across service/controller and fix updateStatus return type.

### DIFF
--- a/src/main/java/com/poryvai/post/controller/ParcelController.java
+++ b/src/main/java/com/poryvai/post/controller/ParcelController.java
@@ -1,9 +1,6 @@
 package com.poryvai.post.controller;
 
-import com.poryvai.post.dto.CreateParcelRequest;
-import com.poryvai.post.dto.ParcelSearchParams;
-import com.poryvai.post.dto.ParcelStatistic;
-import com.poryvai.post.dto.UpdateParcelStatusRequest;
+import com.poryvai.post.dto.*;
 import com.poryvai.post.model.Parcel;
 import com.poryvai.post.model.ParcelStatus;
 import com.poryvai.post.service.ParcelService;
@@ -37,13 +34,13 @@ public class ParcelController {
      * Retrieves a parcel by its unique tracking number.
      *
      * @param trackingNumber The unique tracking number of the parcel, extracted from the URL path.
-     * @return The {@link Parcel} object matching the tracking number.
+     * @return The {@link ParcelResponse} DTO matching the tracking number.
      * This method relies on {@link com.poryvai.post.controller.RestExceptionHandler}
      * to handle {@link com.poryvai.post.exception.NotFoundException}
      * if no parcel is found, returning an HTTP 404.
      */
     @GetMapping("/{trackingNumber}")
-    public Parcel findByTrackingNumber(@PathVariable("trackingNumber") String trackingNumber) {
+    public ParcelResponse findByTrackingNumber(@PathVariable("trackingNumber") String trackingNumber) {
         log.info("Received request to find parcel by tracking number: {}", trackingNumber);
         return parcelService.getByTrackingNumber(trackingNumber);
     }
@@ -56,10 +53,10 @@ public class ParcelController {
      * These parameters are typically passed as request parameters (query string).
      * @param pageable {@link Pageable} object for pagination and sorting (e.g., page=0&size=10&sort=id,asc).
      * Automatically resolved by Spring from request parameters.
-     * @return A {@link Page} of {@link Parcel} objects matching the search criteria.
+     * @return A {@link Page} of {@link ParcelResponse} DTOs matching the search criteria.
      */
     @GetMapping
-    public Page<Parcel> findAll(ParcelSearchParams params, Pageable pageable) {
+    public Page<ParcelResponse> findAll(ParcelSearchParams params, Pageable pageable) {
         log.info("Received request to find all parcels with params: {} and pageable: {}", params, pageable);
         return parcelService.findAll(params, pageable);
     }
@@ -108,14 +105,14 @@ public class ParcelController {
      * @param trackingNumber The unique tracking number of the parcel to update, extracted from the URL path.
      * @param request        The {@link UpdateParcelStatusRequest} object containing the new {@link ParcelStatus}.
      * This object is expected in the request body (JSON).
-     * @return The updated {@link Parcel} object with its new status.
+     * @return The updated {@link ParcelResponse} DTO with its new status.
      * This method relies on {@link com.poryvai.post.controller.RestExceptionHandler}
      * to handle {@link com.poryvai.post.exception.NotFoundException}
      * if no parcel is found, returning an HTTP 404.
      */
     @PatchMapping("/{trackingNumber}")
-    public Parcel updateStatus(@PathVariable("trackingNumber") String trackingNumber,
-                               @RequestBody UpdateParcelStatusRequest request) {
+    public ParcelResponse updateStatus(@PathVariable("trackingNumber") String trackingNumber,
+                                       @RequestBody UpdateParcelStatusRequest request) {
         log.info("Received request to update status for parcel with tracking number {} to {}", trackingNumber,
                 request.getStatus());
         return parcelService.updateStatus(trackingNumber, request.getStatus());

--- a/src/main/java/com/poryvai/post/dto/ParcelResponse.java
+++ b/src/main/java/com/poryvai/post/dto/ParcelResponse.java
@@ -1,0 +1,31 @@
+package com.poryvai.post.dto;
+
+import com.poryvai.post.model.DeliveryType;
+import com.poryvai.post.model.ParcelDescription;
+import com.poryvai.post.model.ParcelStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for representing full Parcel information in API responses.
+ * Includes details of the associated origin and destination Post Offices.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParcelResponse {
+    private Long id;
+    private String trackingNumber;
+    private String sender;
+    private String recipient;
+    private Double weight;
+    private Double price;
+    private ParcelStatus status;
+    private DeliveryType deliveryType;
+    private ParcelDescription parcelDescription;
+    private PostOfficeDto originPostOffice;
+    private PostOfficeDto destinationPostOffice;
+}

--- a/src/main/java/com/poryvai/post/dto/PostOfficeDto.java
+++ b/src/main/java/com/poryvai/post/dto/PostOfficeDto.java
@@ -1,0 +1,23 @@
+package com.poryvai.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for representing Post Office information in API responses.
+ * Provides a simplified view of the PostOffice entity,
+ * suitable for inclusion in other response DTOs (e.g., ParcelResponse, EmployeeResponse).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostOfficeDto {
+    private Long id;
+    private String name;
+    private String city;
+    private String postcode;
+    private String street;
+}

--- a/src/main/java/com/poryvai/post/service/ParcelService.java
+++ b/src/main/java/com/poryvai/post/service/ParcelService.java
@@ -1,6 +1,7 @@
 package com.poryvai.post.service;
 
 import com.poryvai.post.dto.CreateParcelRequest;
+import com.poryvai.post.dto.ParcelResponse;
 import com.poryvai.post.model.Parcel;
 import com.poryvai.post.dto.ParcelSearchParams;
 import com.poryvai.post.dto.ParcelStatistic;
@@ -19,11 +20,11 @@ public interface ParcelService {
      * Retrieves a parcel by its unique tracking number.
      *
      * @param trackingNumber The unique tracking number used to identify the parcel.
-     * @return The {@link Parcel} object corresponding to the given tracking number.
+     * @return The {@link ParcelResponse}  DTO corresponding to the given tracking number.
      * @throws com.poryvai.post.exception.NotFoundException if no parcel with the specified tracking number is found.
      * This exception is typically handled by a global exception handler (e.g., RestExceptionHandler).
      */
-    Parcel getByTrackingNumber(String trackingNumber);
+    ParcelResponse getByTrackingNumber(String trackingNumber);
 
     /**
      * Retrieves a paginated and filtered list of parcels.
@@ -31,9 +32,9 @@ public interface ParcelService {
      *
      * @param params   An object containing optional search criteria (e.g., sender, recipient, status, parcel descriptions).
      * @param pageable An object defining pagination (page number, size) and sorting options.
-     * @return A {@link Page} of {@link Parcel} objects that match the criteria.
+     * @return A {@link Page} of {@link ParcelResponse} DTOs that match the specified criteria.
      */
-    Page<Parcel> findAll(ParcelSearchParams params, Pageable pageable);
+    Page< ParcelResponse> findAll(ParcelSearchParams params, Pageable pageable);
 
     /**
      * Builds and returns a statistical summary of parcels based on specified search parameters.
@@ -62,9 +63,9 @@ public interface ParcelService {
      *
      * @param trackingNumber The unique tracking number of the parcel to be updated.
      * @param status         The new {@link ParcelStatus} to set for the parcel.
-     * @return The updated {@link Parcel} object.
+     * @return The updated {@link ParcelResponse} DTO representing the parcel after the status change.
      * @throws com.poryvai.post.exception.NotFoundException if no parcel with the specified tracking number is found.
      * This exception is typically handled by a global exception handler (e.g., RestExceptionHandler).
      */
-    Parcel updateStatus(String trackingNumber, ParcelStatus status);
+    ParcelResponse updateStatus(String trackingNumber, ParcelStatus status);
 }


### PR DESCRIPTION
This pull request addresses crucial refinements and contract synchronization for the `Parcel` entity's DTOs, which were implemented but not included in the previous deployment cycle. This ensures our API contracts are consistent and robust, especially regarding data serialization.

What's been done:

1. API Contract Consistency:
    - Methods `getByTrackingNumber` and `findAll` in both `ParcelService` and `ParcelController` now consistently return `ParcelResponse` or `Page<ParcelResponse>` DTOs. This resolves potential `ByteBuddyInterceptor` serialization issues by ensuring raw Hibernate entities are not directly exposed in API responses.
2. Centralized DTO Mapping:
    - A new private helper method, `mapParcelToResponse`, has been extracted within `ParcelServiceImpl`. This centralizes the logic for mapping `Parcel` entities to `ParcelResponse` DTOs, promoting code reusability and maintainability.
3. Robust Status Update Logic:
    - The `updateStatus` method in `ParcelServiceImpl` has been refined. It now explicitly fetches the `Parcel` entity from the repository, applies the status update, persists the changes, and then maps the updated entity to a `ParcelResponse` DTO for the return value.
    - The return type for `updateStatus` in the `ParcelService` interface and `ParcelController` has been synchronized to `ParcelResponse` to reflect this change.
4. Optimized Transaction Management:
    - Read-only operations (`getByTrackingNumber`, `findAll`, `buildStatistic`) in `ParcelServiceImpl` are now annotated with `@Transactional(readOnly = true)`. This optimizes database interactions by indicating that these operations do not modify data.
5. Synchronized Javadoc:
    - All relevant Javadoc comments in `ParcelService` and `ParcelController` have been updated to accurately reflect the DTO return types and method behaviors, ensuring documentation matches implementation.

How to Verify:

-  Run the application.
- Use Postman (or similar tool) to test the following endpoints:
    * `GET /api/v1/parcels/{trackingNumber}`: Verify it returns a `ParcelResponse` and includes correct nested `PostOfficeDto` data.
    * `GET /api/v1/parcels` (with and without search parameters/pagination): Verify it returns a `Page<ParcelResponse>`.
    * `PATCH /api/v1/parcels/{trackingNumber}` (with `{"status": "NEW_STATUS"}` in body): Verify the parcel's status is updated and the response is a `ParcelResponse` reflecting the new status.
- Verify data integrity and expected error responses (e.g., 404 for not found).