### PR TITLE
refactor: Unify entity creation/update with Lombok @Builder 

### DIFF
--- a/src/main/java/com/poryvai/post/service/ClientServiceImpl.java
+++ b/src/main/java/com/poryvai/post/service/ClientServiceImpl.java
@@ -32,12 +32,16 @@ public class ClientServiceImpl implements ClientService{
     @Transactional
     public Client create(CreateClientRequest request) {
         log.info("Creating new client with first name: {}, last name: {}", request.getFirstName(), request.getLastName());
-        Client client = new Client();
-        client.setFirstName(request.getFirstName());
-        client.setLastName(request.getLastName());
-        client.setEmail(request.getEmail());
-        client.setPhone(request.getPhone());
-        return clientRepository.save(client);
+        Client client = Client.builder()
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .build();
+
+        Client savedClient = clientRepository.save(client);
+        log.info("Client created successfully with ID: {}", savedClient.getId());
+        return savedClient;
     }
 
     /**

--- a/src/main/java/com/poryvai/post/service/PostOfficeServiceImpl.java
+++ b/src/main/java/com/poryvai/post/service/PostOfficeServiceImpl.java
@@ -33,14 +33,19 @@ public class PostOfficeServiceImpl implements PostOfficeService{
      * @return The newly created and persisted {@link PostOffice} object.
      */
     @Override
+    @Transactional
     public PostOffice create(CreatePostOfficeRequest request) {
         log.info("Creating new post office: {}", request.getName());
-        PostOffice postOffice = new PostOffice();
-        postOffice.setName(request.getName());
-        postOffice.setCity(request.getCity());
-        postOffice.setPostcode(request.getPostcode());
-        postOffice.setStreet(request.getStreet());
-        return postOfficeRepository.save(postOffice);
+        PostOffice postOffice = PostOffice.builder()
+                .name(request.getName())
+                .city(request.getCity())
+                .postcode(request.getPostcode())
+                .street(request.getStreet())
+                .build();
+
+        PostOffice savedPostOffice = postOfficeRepository.save(postOffice);
+        log.info("Post office created successfully with ID: {}", savedPostOffice.getId());
+        return savedPostOffice;
     }
 
     /**


### PR DESCRIPTION

This task focuses on refactoring our service layer to unify the approach for creating and updating entities. Currently, the `create` and `update` methods in `ClientServiceImpl`, `ParcelServiceImpl`, and `PostOfficeServiceImpl` utilize direct setter calls (`new Entity(); entity.setField(...)`). This approach will be updated to leverage Lombok's `@Builder` pattern, which is already enabled on all our entity classes (e.g., `@Builder(toBuilder = true)`).

The primary goal is to enhance code readability, conciseness, and consistency across the service implementations, aligning them with the style adopted in `EmployeeServiceImpl`.

Affected Classes & Methods Refactored:

1.  `ClientServiceImpl`:
    - `create(CreateClientRequest request)`: Changed to use `Client.builder()...build()` for new entity instantiation.

2.  `ParcelServiceImpl`:
    - `create(CreateParcelRequest request)`: Changed to use `Parcel.builder()...build()` for new entity instantiation, including improved handling for `deliveryType` and price calculation within the builder flow.

3.  `PostOfficeServiceImpl`:
    - `create(CreatePostOfficeRequest request)`: Changed to use `PostOffice.builder()...build()` for new entity instantiation.

Benefits of this Refactoring:

- Readability: Cleaner and more expressive code when constructing objects, especially with many fields.
- Conciseness: Reduces boilerplate code compared to explicit setter calls.
- Consistency: Aligns the entity creation style across all service implementations, matching the pattern established in `EmployeeServiceImpl`.
- Reduced Errors: Helps prevent accidental omission of fields during object creation.

Expected Outcome:

- `create` methods in the specified `ServiceImpl` classes now use `Entity.builder()...build()` for new entity instantiation.
- The overall codebase has a more unified and modern Java style for object construction.


Closes #22