### PR TITLE
feat: Relate Employees to PostOffices

### DIFF
--- a/src/main/java/com/poryvai/post/controller/EmployeeController.java
+++ b/src/main/java/com/poryvai/post/controller/EmployeeController.java
@@ -71,6 +71,19 @@ public class EmployeeController {
     }
 
     /**
+     * Retrieves a list of all employees working at a specific post office.
+     *
+     * @param postOfficeId The unique ID of the post office, provided as a query parameter.
+     * @param pageable An object defining pagination (page number, size) and sorting options.
+     * @return A {@link Page} of {@link EmployeeResponse} DTOs.
+     */
+    @GetMapping("/by-post-office")
+    public Page<EmployeeResponse> getEmployeesByPostOffice(@RequestParam Long postOfficeId, Pageable pageable) {
+        log.info("Received request to get employees for post office with ID: {}", postOfficeId);
+        return employeeService.getEmployeesByPostOffice(postOfficeId, pageable);
+    }
+
+    /**
      * Updates an existing employee identified by their ID.
      *
      * @param id The unique ID of the employee to update, extracted from the URL path.

--- a/src/main/java/com/poryvai/post/dto/CreateEmployeeRequest.java
+++ b/src/main/java/com/poryvai/post/dto/CreateEmployeeRequest.java
@@ -1,6 +1,8 @@
 package com.poryvai.post.dto;
 
 import com.poryvai.post.model.EmployeePosition;
+import com.poryvai.post.model.PostOffice;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -41,4 +43,12 @@ public class CreateEmployeeRequest {
      */
     @NotNull(message = "Position cannot be null")
     private EmployeePosition position;
+
+    /**
+     * The ID of the {@link PostOffice} where the employee works.
+     * Must be a positive number and cannot be null.
+     */
+    @NotNull(message = "Post office ID cannot be null")
+    @DecimalMin(value = "1", message = "Post office ID must be a positive number")
+    private Long postOfficeId;
 }

--- a/src/main/java/com/poryvai/post/dto/EmployeeResponse.java
+++ b/src/main/java/com/poryvai/post/dto/EmployeeResponse.java
@@ -19,5 +19,6 @@ public class EmployeeResponse {
     private String firstName;
     private String lastName;
     private EmployeePosition position;
+    private PostOfficeDto postOffice;
 
 }

--- a/src/main/java/com/poryvai/post/dto/UpdateEmployeeRequest.java
+++ b/src/main/java/com/poryvai/post/dto/UpdateEmployeeRequest.java
@@ -42,4 +42,11 @@ public class UpdateEmployeeRequest {
      */
     @NotNull(message = "Position cannot be null for update")
     private EmployeePosition position;
+
+    /**
+     * The ID of the PostOffice where the employee now works.
+     * Must not be null.
+     */
+    @NotNull(message = "Post office ID cannot be null for update")
+    private Long postOfficeId;
 }

--- a/src/main/java/com/poryvai/post/model/Employee.java
+++ b/src/main/java/com/poryvai/post/model/Employee.java
@@ -1,10 +1,8 @@
 package com.poryvai.post.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.FieldNameConstants;
 
 /**
@@ -21,6 +19,7 @@ import lombok.experimental.FieldNameConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldNameConstants
+@ToString(exclude = "postOffice")
 public class Employee {
 
     /**
@@ -50,4 +49,14 @@ public class Employee {
     @Enumerated(EnumType.STRING)
     @Column(name = "position", nullable = false, length = 80)
     private EmployeePosition position;
+
+    /**
+     * The {@link PostOffice} entity representing the post office
+     * where the employee works.
+     * This field establishes a many-to-one relationship with the PostOffice entity.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_office_id", nullable = false)
+    @JsonBackReference
+    private PostOffice postOffice;
 }

--- a/src/main/java/com/poryvai/post/model/PostOffice.java
+++ b/src/main/java/com/poryvai/post/model/PostOffice.java
@@ -1,8 +1,11 @@
 package com.poryvai.post.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldNameConstants;
+
+import java.util.List;
 
 /**
  * Represents a Post Office entity in the system.
@@ -15,6 +18,7 @@ import lombok.experimental.FieldNameConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @FieldNameConstants
+@ToString(exclude = "employees")
 public class PostOffice {
 
     /**
@@ -49,4 +53,13 @@ public class PostOffice {
      */
     @Column(name = "street", nullable = false, length = 255)
     private String street;
+
+    /**
+     * A list of {@link Employee} entities who work at this post office.
+     * This field establishes a one-to-many relationship, where the "postOffice" field
+     * in the Employee entity is the owning side.
+     */
+    @OneToMany(mappedBy = "postOffice", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JsonManagedReference
+    private List<Employee> employees;
 }

--- a/src/main/java/com/poryvai/post/repository/EmployeeRepository.java
+++ b/src/main/java/com/poryvai/post/repository/EmployeeRepository.java
@@ -2,8 +2,11 @@ package com.poryvai.post.repository;
 
 import com.poryvai.post.model.Client;
 import com.poryvai.post.model.Employee;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 
 /**
  * Repository interface for {@link Employee} entities.
@@ -11,4 +14,15 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+
+    /**
+     * Finds all {@link Employee} entities associated with a specific post office.
+     * This method retrieves a list of employees by matching the ID of their
+     * assigned post office.
+     *
+     * @param postOfficeId The unique identifier of the post office.
+     * @param pageable     An object defining pagination and sorting options.
+     * @return A {@link Page} of {@link Employee} entities found for the given post office ID.
+     */
+    Page<Employee> findByPostOfficeId(Long postOfficeId, Pageable pageable);
 }

--- a/src/main/java/com/poryvai/post/repository/ParcelRepository.java
+++ b/src/main/java/com/poryvai/post/repository/ParcelRepository.java
@@ -27,6 +27,4 @@ public interface ParcelRepository extends JpaRepository<Parcel, Long>,
      * @return An {@link Optional} containing the found {@link Parcel}, or an empty Optional if no parcel is found.
      */
     Optional<Parcel> findByTrackingNumber(String trackingNumber);
-
-
 }

--- a/src/main/java/com/poryvai/post/service/EmployeeService.java
+++ b/src/main/java/com/poryvai/post/service/EmployeeService.java
@@ -39,6 +39,17 @@ public interface EmployeeService {
     Page<EmployeeResponse> getAll(Pageable pageable);
 
     /**
+     * Retrieves a paginated list of all employees working at a specific post office.
+     * This method is used to find employees by the ID of their assigned post office,
+     * with support for pagination and sorting.
+     *
+     * @param postOfficeId The unique ID of the post office to search for.
+     * @param pageable     An object defining pagination (page number, size) and sorting options.
+     * @return A {@link Page} of {@link EmployeeResponse} DTOs.
+     */
+    Page<EmployeeResponse> getEmployeesByPostOffice(Long postOfficeId, Pageable pageable);
+
+    /**
      * Updates an existing employee identified by its ID.
      *
      * @param id      The unique ID of the employee to be updated.


### PR DESCRIPTION
This pull request establishes a `ManyToOne` relationship between the `Employee` entity and the `PostOffice` entity. This allows each employee to be directly associated with a specific post office, enhancing data integrity and application logic. It also introduces a more efficient way to query for employees based on their post office.

What's been done:

1. Employee Entity (`com.poryvai.post.model.Employee`):
    - Introduced a `@ManyToOne` relationship for the `postOffice` field, linking employees to a specific `PostOffice` entity.
    - Added `@JsonBackReference` to the `postOffice` field to prevent a `StackOverflowError` during JSON serialization, resolving a cyclic dependency.

2. PostOffice Entity (`com.poryvai.post.model.PostOffice`):
    - Added a `@OneToMany` relationship for the `employees` field, representing the list of employees working at the post office.
    - Added `@JsonManagedReference` to the `employees` field to manage the bidirectional relationship with the `Employee` entity and ensure correct JSON serialization.

3. DTOs (`com.poryvai.post.dto`):
    - `UpdateEmployeeRequest`: Added `postOfficeId` (type `Long`) with `@NotNull` validation, making it a required field for updating an employee's post office.
    - `EmployeeResponse`: Updated to include a `postOffice` field (type `PostOfficeDto`) to display the associated post office in the response.

5. Service Layer (`com.poryvai.post.service`):
    -`EmployeeServiceImpl`:
        * Modified the `create` and `update` methods to fetch the `PostOffice` entity from the `PostOfficeRepository` using the provided `postOfficeId`.
        * Ensured a `NotFoundException` is thrown if the specified `PostOffice` does not exist.
        * Introduced a new method `getEmployeesByPostOffice(Long postOfficeId, Pageable pageable)` for efficient retrieval of employees by a specific post office, supporting pagination.

6. Repository Layer (`com.poryvai.post.repository`):
    - `EmployeeRepository`: Added a new method `findByPostOffice_Id(Long postOfficeId, Pageable pageable)` to leverage Spring Data JPA's query derivation for fetching employees by post office ID.

7. Controller Layer (`com.poryvai.post.controller`):
    - `EmployeeController`: Added a new endpoint `GET /api/v1/employees/by-post-office` that accepts `postOfficeId` as a query parameter, allowing clients to efficiently query employees by their post office.

How to Verify:

- Prerequisites: Ensure your database has at least one `PostOffice` record (e.g., with ID 2). If not, insert one manually.
- Run the application.
- Use Postman (or similar tool) to test the new functionality:
    * Create Employee: `POST /api/v1/employees` with `postOfficeId` in the body.
    * Get Employee: `GET /api/v1/employees/{id}` and verify the `postOffice` object is included in the response.
    * Get Employees by Post Office: `GET /api/v1/employees/by-post-office?postOfficeId=2` and verify you receive a paginated list of employees from that office.
    * Update Employee: `PUT /api/v1/employees/{id}` with `postOfficeId` and other fields to change their assigned post office.
    * Verify cyclic dependency fix: `GET /api/v1/post-offices/{id}` should now return successfully, including a list of its employees without a `StackOverflowError`.


Closes #12
